### PR TITLE
Fix contextGeoArea serialization

### DIFF
--- a/LMGRemoteData.podspec
+++ b/LMGRemoteData.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'LMGRemoteData'
-  s.version          = '1.0.11'
+  s.version          = '1.0.12'
   s.summary          = 'Remote data layer for the LMG iOS SDK'
   s.description      = <<-DESC
 Implements the remote data objects for the LMG iOS SDK.

--- a/LMGRemoteData/Classes/GraphQL/DataAccess Glue/LMGDACoordinate+RemoteData.swift
+++ b/LMGRemoteData/Classes/GraphQL/DataAccess Glue/LMGDACoordinate+RemoteData.swift
@@ -10,6 +10,6 @@ import LMGDataAccess
 
 extension LMGDACoordinate {
     func toRemoteData() -> [Double] {
-        return [self.longitude, self.latitude]
+        return [self.latitude, self.longitude]
     }
 }


### PR DESCRIPTION
Fixes ```Error Domain=com.loopmediagroup.remotedata Code=4000 "Api Request Failed" UserInfo={NSLocalizedRecoverySuggestion=Please see underlying error., NSUnderlyingError=0x604000488250 {Error Domain=Apollo.GraphQLError Code=1 "400 - {"message":"Invalid Value for query-Parameter \"contextGeoArea\" provided.","messageId":99003,"context":{"value":"[[-119.80263850316413,50.12445791757244],[-119.10669377222649,50.12445791757244],[-119.10669377222649,49.67492715322834],[-119.80263850316413,49.67492715322834],[-119.80263850316413,50.12445791757244]]"}}"}, NSLocalizedFailureReason=Api Request Failed}```