### PR TITLE
Reverts incorrect location serialization ordering adjustment

### DIFF
--- a/LMGRemoteData/Classes/GraphQL/DataAccess Glue/LMGDACoordinate+RemoteData.swift
+++ b/LMGRemoteData/Classes/GraphQL/DataAccess Glue/LMGDACoordinate+RemoteData.swift
@@ -10,6 +10,6 @@ import LMGDataAccess
 
 extension LMGDACoordinate {
     func toRemoteData() -> [Double] {
-        return [self.latitude, self.longitude]
+        return [self.longitude, self.latitude]
     }
 }


### PR DESCRIPTION
Was correct to begin with. Root cause of issue was incorrectly communicated.