### PR TITLE
Added business to locations

### DIFF
--- a/LMGRemoteData.podspec
+++ b/LMGRemoteData.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'LMGRemoteData'
-  s.version          = '1.0.22'
+  s.version          = '1.0.23'
   s.summary          = 'Remote data layer for the LMG iOS SDK'
   s.description      = <<-DESC
 Implements the remote data objects for the LMG iOS SDK.

--- a/LMGRemoteData/Classes/GraphQL/DataAccess Glue/OfferDetailsQuery+DataAccess.swift
+++ b/LMGRemoteData/Classes/GraphQL/DataAccess Glue/OfferDetailsQuery+DataAccess.swift
@@ -46,7 +46,14 @@ extension OfferDetails {
         }
         builder.business = business.fragments.businessListItem.toDataAccess(locations: nil, offers: nil)
         builder.images = heroImages.compactMap { $0.url }
-        builder.locations = locations
+        
+        builder.locations = locations.map({
+            let locationBuilder = LMGDALocationBuilder($0)
+            locationBuilder.business = builder.business
+            
+            return locationBuilder.build()
+        })
+        
         return builder.build()
     }
 }


### PR DESCRIPTION
Added business to locations (Offer query).

This needs to be one for one reason. In the offer details screen, there is a collection view with locations. To configure its cells, LMGLocation object is used, which conforms to protocol LMGLocationCardCellPresentable. Its **hasWebsite** & **hasPhoneNumber** didn't have a business object before, which is necessary for returning the correct value for these methods.